### PR TITLE
Multi Networks Support

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -61,7 +61,11 @@ func extractPodBandwidthResources(podAnnotations map[string]string) (int64, int6
 func (pr *PodRequest) cmdAdd() *PodResult {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
-	if namespace == "" || podName == "" {
+
+	networkName := pr.CNIConf.Name
+	logrus.Infof("Adding interface for network = %s", networkName)
+
+	if namespace == "" || podName == "" || networkName == "" {
 		logrus.Errorf("required CNI variable missing")
 		return nil
 	}
@@ -72,6 +76,12 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 		return nil
 	}
 	kubecli := &kube.Kube{KClient: clientset}
+
+	isDefaultInterface := networkName == "ovn-kubernetes"
+	ovnAnnotationKey := "ovn"
+	if !isDefaultInterface {
+		ovnAnnotationKey = "ovn_extra"
+	}
 
 	// Get the IP address and MAC address from the API server.
 	// Exponential back off ~32 seconds + 7* t(api call)
@@ -84,7 +94,7 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 			logrus.Warningf("Error while obtaining pod annotations - %v", err)
 			return false, nil
 		}
-		if _, ok := annotation["ovn"]; ok {
+		if _, ok := annotation[ovnAnnotationKey]; ok {
 			return true, nil
 		}
 		return false, nil
@@ -93,24 +103,45 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 		return nil
 	}
 
-	ovnAnnotation, ok := annotation["ovn"]
-	if !ok {
-		logrus.Errorf("failed to get ovn annotation from pod")
-		return nil
+	var ovnNetworkAnnotatedMap map[string]string
+	if isDefaultInterface {
+		ovnAnnotation, ok := annotation[ovnAnnotationKey]
+		if !ok {
+			logrus.Errorf("failed to get ovn annotation from pod")
+			return nil
+		}
+
+		err = json.Unmarshal([]byte(ovnAnnotation), &ovnNetworkAnnotatedMap)
+		if err != nil {
+			logrus.Errorf("failed to unmarshal ovn annotation: %v", err)
+			return nil
+		}
+	} else {
+		ovnExtraAnnotation, ok := annotation[ovnAnnotationKey]
+		if !ok {
+			logrus.Errorf("failed to get ovn_extra annotation from pod")
+			return nil
+		}
+		var ovnExtraAnnotatedMap map[string]map[string]string
+
+		err = json.Unmarshal([]byte(ovnExtraAnnotation), &ovnExtraAnnotatedMap)
+		if err != nil {
+			logrus.Errorf("failed to unmarshal ovn_extra annotation: %v", err)
+			return nil
+		}
+
+		ovnNetworkAnnotatedMap, ok = ovnExtraAnnotatedMap[networkName]
+		if !ok {
+			logrus.Errorf("failed to get the infromation of network %s from pod's ovn_extra annotation", networkName)
+			return nil
+		}
 	}
 
-	var ovnAnnotatedMap map[string]string
-	err = json.Unmarshal([]byte(ovnAnnotation), &ovnAnnotatedMap)
-	if err != nil {
-		logrus.Errorf("unmarshal ovn annotation failed")
-		return nil
-	}
+	ipAddress := ovnNetworkAnnotatedMap["ip_address"]
+	macAddress := ovnNetworkAnnotatedMap["mac_address"]
+	gatewayIP := ovnNetworkAnnotatedMap["gateway_ip"]
 
-	ipAddress := ovnAnnotatedMap["ip_address"]
-	macAddress := ovnAnnotatedMap["mac_address"]
-	gatewayIP := ovnAnnotatedMap["gateway_ip"]
-
-	if ipAddress == "" || macAddress == "" || gatewayIP == "" {
+	if ipAddress == "" || macAddress == "" || (isDefaultInterface && gatewayIP == "") {
 		logrus.Errorf("failed in pod annotation key extract")
 		return nil
 	}
@@ -122,7 +153,7 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 	}
 
 	var interfacesArray []*current.Interface
-	interfacesArray, err = pr.ConfigureInterface(namespace, podName, macAddress, ipAddress, gatewayIP, config.Default.MTU, ingress, egress)
+	interfacesArray, err = pr.ConfigureInterface(namespace, podName, networkName, macAddress, ipAddress, gatewayIP, config.Default.MTU, ingress, egress)
 	if err != nil {
 		logrus.Errorf("Failed to configure interface in pod: %v", err)
 		return nil

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -35,7 +35,7 @@ func renameLink(curName, newName string) error {
 	return nil
 }
 
-func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, gatewayIP string, mtu int) (*current.Interface, *current.Interface, error) {
+func setupInterface(netns ns.NetNS, hostIfaceName, ifName, macAddress, ipAddress, gatewayIP string, mtu int, isDefaultInterface bool) (*current.Interface, *current.Interface, error) {
 	hostIface := &current.Interface{}
 	contIface := &current.Interface{}
 
@@ -46,6 +46,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 		if err != nil {
 			return err
 		}
+
 		hostIface.Mac = hostVeth.HardwareAddr.String()
 		contIface.Name = containerVeth.Name
 
@@ -75,12 +76,14 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 		}
 
 		gw := net.ParseIP(gatewayIP)
-		if gw == nil {
+		if gw == nil && isDefaultInterface {
 			return fmt.Errorf("parse ip of gateway failed")
 		}
-		err = ip.AddRoute(nil, gw, link)
-		if err != nil {
-			return err
+		if gw != nil {
+			err = ip.AddRoute(nil, gw, link)
+			if err != nil {
+				return err
+			}
 		}
 
 		oldHostVethName = hostVeth.Name
@@ -92,7 +95,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 	}
 
 	// rename the host end of veth pair
-	hostIface.Name = containerID[:15]
+	hostIface.Name = hostIfaceName
 	if err := renameLink(oldHostVethName, hostIface.Name); err != nil {
 		return nil, nil, fmt.Errorf("failed to rename %s to %s: %v", oldHostVethName, hostIface.Name, err)
 	}
@@ -101,19 +104,31 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 }
 
 // ConfigureInterface sets up the container interface
-func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(namespace string, podName string, networkName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
 	netns, err := ns.GetNS(pr.Netns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open netns %q: %v", pr.Netns, err)
 	}
 	defer netns.Close()
 
-	hostIface, contIface, err := setupInterface(netns, pr.SandboxID, pr.IfName, macAddress, ipAddress, gatewayIP, mtu)
+	isDefaultInterface := isDefaultInterface(networkName)
+	var ifaceID string
+	var hostIfaceName string
+	if isDefaultInterface {
+		ifaceID = fmt.Sprintf("%s_%s", namespace, podName)
+		hostIfaceName = pr.SandboxID[:15]
+	} else {
+		ifaceID = fmt.Sprintf("%s_%s_%s", namespace, podName, networkName)
+		hostIfaceName, err = ip.RandomVethName()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	hostIface, contIface, err := setupInterface(netns, hostIfaceName, pr.IfName, macAddress, ipAddress, gatewayIP, mtu, isDefaultInterface)
 	if err != nil {
 		return nil, err
 	}
-
-	ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
 
 	ovsArgs := []string{
 		"add-port", "br-int", hostIface.Name, "--", "set",
@@ -127,21 +142,23 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAd
 		return nil, fmt.Errorf("failure in plugging pod interface: %v\n  %q", err, out)
 	}
 
-	if err := clearPodBandwidth(pr.SandboxID); err != nil {
-		return nil, err
-	}
-	if ingress > 0 || egress > 0 {
-		l, err := netlink.LinkByName(hostIface.Name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find host veth interface %s: %v", hostIface.Name, err)
-		}
-		err = netlink.LinkSetTxQLen(l, 1000)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set host veth txqlen: %v", err)
-		}
-
-		if err := setPodBandwidth(pr.SandboxID, hostIface.Name, ingress, egress); err != nil {
+	if isDefaultInterface {
+		if err := clearPodBandwidth(pr.SandboxID); err != nil {
 			return nil, err
+		}
+		if ingress > 0 || egress > 0 {
+			l, err := netlink.LinkByName(hostIface.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find host veth interface %s: %v", hostIface.Name, err)
+			}
+			err = netlink.LinkSetTxQLen(l, 1000)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set host veth txqlen: %v", err)
+			}
+
+			if err := setPodBandwidth(pr.SandboxID, hostIface.Name, ingress, egress); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -150,17 +167,39 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAd
 
 // PlatformSpecificCleanup deletes the OVS port
 func (pr *PodRequest) PlatformSpecificCleanup() error {
-	ifaceName := pr.SandboxID[:15]
-	ovsArgs := []string{
-		"del-port", "br-int", ifaceName,
-	}
-	out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "no port named") {
-		// DEL should be idempotent; don't return an error just log it
-		logrus.Warningf("failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
+	networkName := pr.CNIConf.Name
+	var portList []string
+	isDefaultInterface := isDefaultInterface(networkName)
+	if isDefaultInterface {
+		portList = make([]string, 1)
+		portList[0] = pr.SandboxID[:15]
+	} else {
+		var err error
+		ifaceName := fmt.Sprintf("%s_%s_%s", pr.PodNamespace, pr.PodName, networkName)
+		portList, err = ovsFind("interface", "name", fmt.Sprintf("external-ids:iface-id=%s", ifaceName))
+		if err != nil {
+			logrus.Infof("failed to find OVS port with external-ids:iface-id: %s  error: %v", ifaceName, err)
+		}
 	}
 
-	_ = clearPodBandwidth(pr.SandboxID)
+	for _, ifaceName := range portList {
+		ovsArgs := []string{
+			"del-port", "br-int", ifaceName,
+		}
+		out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
+		if err != nil && !strings.Contains(string(out), "no port named") {
+			// DEL should be idempotent; don't return an error just log it
+			logrus.Warningf("failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
+		}
+	}
+
+	if isDefaultInterface {
+		_ = clearPodBandwidth(pr.SandboxID)
+	}
 
 	return nil
+}
+
+func isDefaultInterface(networkName string) bool {
+	return networkName == "ovn-kubernetes"
 }

--- a/go-controller/pkg/cni/helper_windows.go
+++ b/go-controller/pkg/cni/helper_windows.go
@@ -109,7 +109,11 @@ func deleteHNSEndpoint(endpointName string) error {
 // The fact that CNI add should be idempotent on Windows is stated here:
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/cni/cni_windows.go#L38
 // TODO: add proper MTU config (GetCurrentThreadId/SetCurrentThreadId) or via OVS properties
-func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(namespace string, podName string, networkName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+	if networkName != "ovn-kubernetes" {
+		return nil, fmt.Errorf("Cannot add network %s to pod %s. Non-default networks are currently not supported on windows", networkName, podName)
+	}
+
 	conf := pr.CNIConf
 	ipAddr, ipNet, err := net.ParseCIDR(ipAddress)
 	if err != nil {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -2,6 +2,8 @@ package ovn
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,7 +13,7 @@ import (
 )
 
 func (oc *Controller) syncPods(pods []interface{}) {
-	// get the list of logical switch ports (equivalent to pods)
+	// get the list of logical switch ports
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)
@@ -21,6 +23,14 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		}
 		logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 		expectedLogicalPorts[logicalPort] = true
+
+		switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations)
+		if switches != nil {
+			for _, logicalSwitch := range switches {
+				logicalPort := fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, logicalSwitch)
+				expectedLogicalPorts[logicalPort] = true
+			}
+		}
 	}
 
 	// get the list of logical ports from OVN
@@ -117,6 +127,29 @@ func (oc *Controller) getLogicalPortUUID(logicalPort string) string {
 	return oc.logicalPortUUIDCache[logicalPort]
 }
 
+func (oc *Controller) getMaskFromSubnet(logicalSwitch string) (string, error) {
+	subnet, stderr, err := util.RunOVNNbctlHA("get", "logical_switch",
+		logicalSwitch, "other-config:subnet")
+	if err != nil {
+		logrus.Errorf("failed to get the logical_switch %s subnet, "+
+			"stderr: %q (%v)", logicalSwitch, stderr, err)
+		return "", err
+	}
+
+	if subnet == "" {
+		return "", fmt.Errorf("Empty subnet in logical switch %s",
+			logicalSwitch)
+	}
+
+	_, subnetNet, err := net.ParseCIDR(subnet)
+	if err != nil {
+		logrus.Errorf("failed to parse subnet %s", subnet)
+		return "", err
+	}
+	mask, _ := subnetNet.Mask.Size()
+	return strconv.Itoa(mask), nil
+}
+
 func (oc *Controller) getGatewayFromSwitch(logicalSwitch string) (string, string, error) {
 	var gatewayIPMaskStr, stderr string
 	var ok bool
@@ -149,43 +182,61 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	}
 
 	logrus.Infof("Deleting pod: %s", pod.Name)
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
-	out, stderr, err := util.RunOVNNbctlHA("--if-exists", "lsp-del",
-		logicalPort)
-	if err != nil {
-		logrus.Errorf("Error in deleting pod logical port "+
-			"stdout: %q, stderr: %q, (%v)",
-			out, stderr, err)
+
+	podLogicalPorts := make(map[string]string)
+	switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations)
+	if switches != nil {
+		for _, logicalSwitch := range switches {
+			podLogicalPorts[logicalSwitch] = fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, logicalSwitch)
+		}
+	}
+	podLogicalPorts[""] = fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+
+	for logicalSwitch, logicalPort := range podLogicalPorts {
+		out, stderr, err := util.RunOVNNbctlHA("--if-exists", "lsp-del",
+			logicalPort)
+		if err != nil {
+			logrus.Errorf("Error in deleting pod logical port "+
+				"stdout: %q, stderr: %q, (%v)",
+				out, stderr, err)
+		}
+
+		var ipAddress string
+		if logicalSwitch == "" {
+			ipAddress = oc.getIPFromOvnAnnotation(pod.Annotations["ovn"])
+		} else {
+			networkAnntationMap := oc.getNetworkInfoFromOvnAnnotation(pod.Annotations["ovn_extra"], logicalSwitch)
+			ipAddress = oc.getIPFromOvnAnnotationMap(networkAnntationMap)
+		}
+
+		delete(oc.logicalPortCache, logicalPort)
+
+		oc.lspMutex.Lock()
+		delete(oc.lspIngressDenyCache, logicalPort)
+		delete(oc.lspEgressDenyCache, logicalPort)
+		delete(oc.logicalPortUUIDCache, logicalPort)
+		oc.lspMutex.Unlock()
+
+		if !oc.portGroupSupport {
+			oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,
+				"Ingress")
+			oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,
+				"Egress")
+		}
+		oc.deletePodFromNamespaceAddressSet(pod.Namespace, ipAddress)
 	}
 
-	ipAddress := oc.getIPFromOvnAnnotation(pod.Annotations["ovn"])
-
-	delete(oc.logicalPortCache, logicalPort)
-
-	oc.lspMutex.Lock()
-	delete(oc.lspIngressDenyCache, logicalPort)
-	delete(oc.lspEgressDenyCache, logicalPort)
-	delete(oc.logicalPortUUIDCache, logicalPort)
-	oc.lspMutex.Unlock()
-
-	if !oc.portGroupSupport {
-		oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,
-			"Ingress")
-		oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,
-			"Egress")
-	}
-	oc.deletePodFromNamespaceAddressSet(pod.Namespace, ipAddress)
 	return
 }
 
-func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
+func (oc *Controller) addLogicalPort(pod *kapi.Pod, logicalSwitch string) (newAnnotation string) {
 	var out, stderr string
 	var err error
+
 	if pod.Spec.HostNetwork {
 		return
 	}
 
-	logicalSwitch := pod.Spec.NodeName
 	if logicalSwitch == "" {
 		logrus.Errorf("Failed to find the logical switch for pod %s/%s",
 			pod.Namespace, pod.Name)
@@ -197,16 +248,34 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		oc.addAllowACLFromNode(logicalSwitch)
 	}
 
-	portName := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	var portName string
+	isDefaultPort := logicalSwitch == pod.Spec.NodeName
+
+	if isDefaultPort {
+		portName = fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	} else {
+		portName = fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, logicalSwitch)
+	}
+
 	logrus.Debugf("Creating logical port for %s on switch %s", portName, logicalSwitch)
 
-	annotation, isStaticIP := pod.Annotations["ovn"]
+	var ovnNetworkAnnotatedMap map[string]string
+	var isStaticIP bool
+	if isDefaultPort {
+		var annotation string
+		annotation, isStaticIP = pod.Annotations["ovn"]
+		ovnNetworkAnnotatedMap = oc.getOvnAnnotationMap(annotation)
+	} else {
+		ovnExtraAnnotation, _ := pod.Annotations["ovn_extra"]
+		ovnNetworkAnnotatedMap = oc.getNetworkInfoFromOvnAnnotation(ovnExtraAnnotation, logicalSwitch)
+		isStaticIP = ovnNetworkAnnotatedMap != nil
+	}
 
 	// If pod already has annotations, just add the lsp with static ip/mac.
 	// Else, create the lsp with dynamic addresses.
 	if isStaticIP {
-		ipAddress := oc.getIPFromOvnAnnotation(annotation)
-		macAddress := oc.getMacFromOvnAnnotation(annotation)
+		ipAddress := oc.getIPFromOvnAnnotationMap(ovnNetworkAnnotatedMap)
+		macAddress := oc.getMacFromOvnAnnotationMap(ovnNetworkAnnotatedMap)
 
 		out, stderr, err = util.RunOVNNbctlHA("--may-exist", "lsp-add",
 			logicalSwitch, portName, "--", "lsp-set-addresses", portName,
@@ -238,9 +307,18 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	oc.logicalPortCache[portName] = logicalSwitch
 
 	gatewayIP, mask, err := oc.getGatewayFromSwitch(logicalSwitch)
-	if err != nil {
+	if isDefaultPort && err != nil {
 		logrus.Errorf("Error obtaining gateway address for switch %s", logicalSwitch)
 		return
+	}
+
+	if !isDefaultPort && gatewayIP == "" {
+		mask, err = oc.getMaskFromSubnet(logicalSwitch)
+		if err != nil {
+			logrus.Errorf("Error obtaining gateway address for switch %s", logicalSwitch)
+			return
+		}
+
 	}
 
 	count := 30
@@ -277,20 +355,15 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	addresses := strings.Split(outStr, " ")
 	if len(addresses) != 2 {
 		logrus.Errorf("Error while obtaining addresses for %s", portName)
-		return
+		return ""
 	}
 
-	if !isStaticIP {
-		annotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, addresses[1], mask, addresses[0], gatewayIP)
-		logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s", addresses[1], mask, addresses[0], gatewayIP, annotation)
-		err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
-		if err != nil {
-			logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
-		}
-	}
+	newAnnotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, addresses[1], mask, addresses[0], gatewayIP)
+	logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%v", addresses[1], mask, addresses[0], gatewayIP, ovnNetworkAnnotatedMap)
+
 	oc.addPodToNamespaceAddressSet(pod.Namespace, addresses[1])
 
-	return
+	return newAnnotation
 }
 
 // AddLogicalPortWithIP add logical port with static ip address


### PR DESCRIPTION
The purpose of this PR is to extend ovn-kubernetes to support multiple networks.
The secondary networks will be added using multus (or any other solution complies with the de-facto standard).

It means the pods annotation should contain the required network attachments under - 'k8s.v1.cni.cncf.io/networks'.

```apiVersion: v1
kind: Pod
metadata:
  name: pod-with-multiple-ovn-networks
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
            { "name": "blue-network-attachment”},
            { "name": "red-network-attachment”}
    ]'
   switches: [“blue-network”, “red-network”]
...
```

The network attachment CRD should contain the name of the logical switch represents the logical network in the config section.

```apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: “blue-network-attachment”
spec: 
  config: '{
    “name”: “blue-network”
    "cniVersion": "0.3.1",
    "type": "ovn-k8s-cni-overlay",
    "Ipam":{},
    "dns":{}
  }'
```

Once the pod will be started, multus will invoke on the minion the binary 'ovn-k8s-cni-overlay' per each pod's network attachment with the type 'ovn-k8s-cni-overlay'.

The ovn-kubernetes code is changed in the following way -

Master

1. **Once the 'watcher' gets a 'pod ADD' event** from k8s API server, it will read the 'switches' annotation from the pod and **create a logical port per switch** in OVN. **For a logical switch named “logicalSwitchName”, the name of the logical port will be "namespace_podName_logicalSwitchName"**. The default logical port will be created the same way as before (the port will be called "namespace_podName" and will be created on the logical switch having the name of the node).
Each newly created logical port in OVN will have "dynamic" address (OVN will assign per each port with “dynamic” address an IP address and MAC address).
3. **Per each port, the watcher will write the assigned IP/MAC into the pod object annotation under the key "ovn_exrta".**

```apiVersion: v1
kind: Pod
metadata:
  name: pod-with-multiple-ovn-networks
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
            { "name": "blue-network-attachment"},
            { "name": "red-network-attachment"},
              ]'
    ...

   switches: [“blue-network”, “red-network”]

   ovn = 
    {"ip_address":"10.244.0.5/24",
     "mac_address":"0a:00:00:00:00:15",
     "gateway_ip": "10.244.0.1"}

   ovn_extra=
    {"blue-network" :
      {"ip_address":"192.168.0.2/24",
       "mac_address":"0a:00:00:00:00:01",
       "gateway_ip": ""}
      },
    "red-network":
      {"ip_address":"10.234.0.3/24",
       "mac_address":"0a:00:00:00:00:02",
       "gateway_ip": ""
      },
      …
```

Minion
1. **Multus invokes the 'ovn-k8s-cni-overlay' per each interface** (of course only network interfaces that are using network attachment with the type - 'ovn-k8s-cni-overlay').
2. **The CNI binary ('ovn-k8s-cni-overlay') reads the annotation of the relevant network from the pod** object 'ovn_extra' section and sets up the network namespace of the container.
3. A veth pair is created in the container and then the host end is moved into host netns.
4. **A new port is created on “br-int”** connecting the host-end to the switch **with "external_ids:iface-id: namespace_podName_logicalSwitchName”** (the logicalSwitchName is taken from the NetworkAttachment and passed by multus to the minion binary (same as the other values from the config section of the network attachment).

Notes -
1. The secondary ovn-kubernetes networks can be added whether ovn-kubernetes is the primary network or not.
However, currently, the master side will create all the 'default' network infrastructure on the ovn north db even if ovn-kubernetes is not used as the primary network. The minion side won't be invoked for the default network in case ovn-kubernetes is not the primary cni.
2. Interfaces on the same pod connected to the same network/logical switch are currently not supported (since the name of logical port is namespace_podName_switchName and we cannot have multiple ports with the same name).
2. Reviewers, please share your thoughts regarding - 
   2.1 Instead of the 'switches' annotation on the pod, taking the switch name directly from the NetworkAttachment CRD.
  2.2 Instead of the 'ovn_extra' annotation, writing the mac/ip/gateway to the pod's multus annotation.

[5 minutes demo](https://asciinema.org/a/P6r9q59sxQxrY5wgfdnYbAFnw
)
[For more details](https://docs.google.com/document/d/1M2SFLEvp34GPZnhEf_D8ZeMY3ZAztgiulN5J-SKHj3Q/edit?ts=5bacc332#)
