### PR TITLE
Networks from crd

### DIFF
--- a/go-controller/pkg/kube/types.go
+++ b/go-controller/pkg/kube/types.go
@@ -1,0 +1,31 @@
+package kube
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NetworkAttachmentDefinition describes a network configuration for CNI
+type NetworkAttachmentDefinition struct {
+	metav1.TypeMeta `json:",inline"`
+	// Note that ObjectMeta is mandatory, as an object
+	// name is required
+	Metadata metav1.ObjectMeta `json:"metadata,omitempty" description:"standard object metadata"`
+
+	// Specification describing how to invoke a CNI plugin to
+	// add or remove network attachments for a Pod.
+	// In the absence of valid keys in a Spec, the runtime (or
+	// meta-plugin) should load and execute a CNI .configlist
+	// or .config (in that order) file on-disk whose JSON
+	// “name” key matches this Network object’s name.
+	// +optional
+	Spec NetworkAttachmentDefinitionSpec `json:"spec"`
+}
+
+type NetworkAttachmentDefinitionSpec struct {
+	// Config contains a standard JSON-encoded CNI configuration
+	// or configuration list which defines the plugin chain to
+	// execute.  If present, this key takes precedence over
+	// ‘Plugin’.
+	// +optional
+	Config string `json:"config"`
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -134,8 +134,8 @@ func (oc *Controller) addDefaultLogicalPort(pod *kapi.Pod) {
 }
 
 func (oc *Controller) addLogicalPortsToExtraSwitches(pod *kapi.Pod) {
-	switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations)
-	if switches != nil {
+	switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations, pod.Namespace)
+	if switches != nil && len(switches) > 0 {
 		annotations := make(map[string]string)
 		for _, logicalSwitch := range switches {
 			annotations[logicalSwitch] = oc.addLogicalPort(pod, logicalSwitch)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -24,7 +24,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 		expectedLogicalPorts[logicalPort] = true
 
-		switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations)
+		switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations, pod.Namespace)
 		if switches != nil {
 			for _, logicalSwitch := range switches {
 				logicalPort := fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, logicalSwitch)
@@ -184,7 +184,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	logrus.Infof("Deleting pod: %s", pod.Name)
 
 	podLogicalPorts := make(map[string]string)
-	switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations)
+	switches := oc.getNetworkNamesFromPodAnnotations(pod.Annotations, pod.Namespace)
 	if switches != nil {
 		for _, logicalSwitch := range switches {
 			podLogicalPorts[logicalSwitch] = fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, logicalSwitch)


### PR DESCRIPTION
The PR that has introduced the multiple networks (https://github.com/openvswitch/ovn-kubernetes/pull/470) is using the 'pod.switches' annotation in the master side, to find out the names of the switches logical ports should be created on.
This 'pod.switches' annotation introduces duplicity, since the 'NetworkAttachment.spec.config.name' also contains the switch/network name (and as to the previous PR is used only by the minion).

This PR changes the master to read the switch/network name directly from the NetworkAttachment crd and eliminates the need for the 'switches' annotation on the pod.